### PR TITLE
index.html: Fix a past event link that incorrectly links to the LA event

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@
       <h2>Past Events</h2>
 
       <ul>
-        <li><a href="https://www.facebook.com/events/230585827354971/">
+        <li><a href="https://www.facebook.com/events/366189077065058/">
           San Francisco Hackathon &middot; Nov 18th-20th
         </a></li>
       </ul>


### PR DESCRIPTION
"Past event" link should properly link to this FB page for SF1:
https://www.facebook.com/events/366189077065058/