### PR TITLE
[Final] Some post SF2 site updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,9 +38,6 @@
       <h2>Upcoming Events</h2>
 
       <ul>
-        <li><a href="https://www.facebook.com/events/1088697797917934">
-          San Francisco Hackathon II &middot; Dec 9th-11th
-           </a></li>
         <li><a href="https://www.facebook.com/events/340431549650508/">
           New York Hackathon &middot; Jan 13th-15th
         </a></li>
@@ -54,6 +51,9 @@
       <h2>Past Events</h2>
 
       <ul>
+        <li><a href="https://www.facebook.com/events/1088697797917934">
+          San Francisco Hackathon II &middot; Dec 9th-11th
+           </a></li>
         <li><a href="https://www.facebook.com/events/366189077065058/">
           San Francisco Hackathon &middot; Nov 18th-20th
         </a></li>

--- a/index.html
+++ b/index.html
@@ -76,6 +76,18 @@
         <li><a href="http://www.huffingtonpost.com/entry/582e22f7e4b0eaa5f14d4248?timestamp=1479418839791">
           Huffington Post &middot; Nonpartisan Hackathons Go Viral Following 2016 Election
         </a></li>
+        <li><a href="http://www.sfchronicle.com/politics/article/The-Resistance-to-Trump-is-rooted-in-the-Bay-Area-10786957.php">
+          San Francisco Chronicle &middot; The Resistance to Trump is rooted in the Bay Area
+        </li></a>
+        <li><a href="https://www.ft.com/content/8ecc63ea-b4f5-11e6-ba85-95d1533d9a62">
+          Financial Times &middot; 'Hackathon' attempts to stem proliferation of fake news
+        </a></li>
+        <li><a href="http://avc.com/2016/12/debug-politics-nyc/">
+          AVC &middot; Debug Politics NYC
+        </li></a>
+        <li><a href="http://www.huffingtonpost.com/entry/5841b3fde4b0cf3f6455894f">
+          Huffington Post &middot; First Products Out of Debug Politics Tackle Fake News and Civic Engagement
+        </a></li>
       </ul>
     </section>
 


### PR DESCRIPTION
Two updates:
 - Moved SF2 facebook event down into the Past Events section
 - Added four more links to the list of Press